### PR TITLE
labels are not generated for Radio: fixed

### DIFF
--- a/templates/scaffold/fields/radio.stub
+++ b/templates/scaffold/fields/radio.stub
@@ -1,3 +1,3 @@
     <label class="radio-inline">
-        {!! Form::radio('$FIELD_NAME$', "$VALUE$", null) !!} $VALUE$
+        {!! Form::radio('$FIELD_NAME$', "$VALUE$", null) !!} $LABEL$
     </label>


### PR DESCRIPTION
Hi,

as I mentioned in [this issue](https://github.com/InfyOmLabs/laravel-generator/issues/283) labels for `select` and `radio`s are not generated. 
Please also update in 5.2
