### PR TITLE
fix: replace date input type to text  input type (issue #795)

### DIFF
--- a/templates/scaffold/fields/date.stub
+++ b/templates/scaffold/fields/date.stub
@@ -1,14 +1,15 @@
 <!-- $FIELD_NAME_TITLE$ Field -->
 <div class="form-group col-sm-6">
     {!! Form::label('$FIELD_NAME$', '$FIELD_NAME_TITLE$:') !!}
-    {!! Form::date('$FIELD_NAME$', null, ['class' => 'form-control','id'=>'$FIELD_NAME$']) !!}
+    {!! Form::text('$FIELD_NAME$', null, ['class' => 'form-control','id'=>'$FIELD_NAME$']) !!}
 </div>
 
 @section('scripts')
     <script type="text/javascript">
         $('#$FIELD_NAME$').datetimepicker({
             format: 'YYYY-MM-DD HH:mm:ss',
-            useCurrent: false
+            useCurrent: true,
+            sideBySide: true
         })
     </script>
 @endsection


### PR DESCRIPTION
What change?
Replace date input type to text input type 

Ref: https://github.com/InfyOmLabs/laravel-generator/issues/795

How to Test:
* Generate Scaffold with date input type and date selection should be working