### PR TITLE
Changing @push to @section

### DIFF
--- a/templates/scaffold/views/datatable_body.stub
+++ b/templates/scaffold/views/datatable_body.stub
@@ -4,7 +4,7 @@
 
 {!! $dataTable->table(['width' => '100%', 'class' => 'table table-striped table-bordered']) !!}
 
-@push('third_party_scripts')
+@section('third_party_scripts')
     @include('layouts.datatables_js')
     {!! $dataTable->scripts() !!}
-@endpush
+@endsection


### PR DESCRIPTION
In the layouts/app.php, 'third_party_scripts' is initialized as yield. Using @push('third_party_scripts') does not add the relevant files to that section, due to which dataTable is not initialized