### PR TITLE
Edit, View, Delete Icon not displaying

### DIFF
--- a/templates/scaffold/views/datatables_actions.stub
+++ b/templates/scaffold/views/datatables_actions.stub
@@ -1,12 +1,12 @@
 {!! Form::open(['route' => ['$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy', $$PRIMARY_KEY_NAME$], 'method' => 'delete']) !!}
 <div class='btn-group'>
     <a href="{{ route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.show', $$PRIMARY_KEY_NAME$) }}" class='btn btn-default btn-xs'>
-        <i class="glyphicon glyphicon-eye-open"></i>
+        <i class="fa fa-eye"></i>
     </a>
     <a href="{{ route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.edit', $$PRIMARY_KEY_NAME$) }}" class='btn btn-default btn-xs'>
-        <i class="glyphicon glyphicon-edit"></i>
+        <i class="fa fa-edit"></i>
     </a>
-    {!! Form::button('<i class="glyphicon glyphicon-trash"></i>', [
+    {!! Form::button('<i class="fa fa-trash"></i>', [
         'type' => 'submit',
         'class' => 'btn btn-danger btn-xs',
         'onclick' => "return confirm('Are you sure?')"


### PR DESCRIPTION
The bootstrap 3 icon classes were not displaying as they were removed in Bootstrap 4. As the theme uses Bootstrap 4 and Font Awesome Icons are already included. The icons are replaced with similar ones from Font Awesome