### PR TITLE
DataTable scripts not being included

### DIFF
--- a/templates/scaffold/views/datatable_body.stub
+++ b/templates/scaffold/views/datatable_body.stub
@@ -4,7 +4,7 @@
 
 {!! $dataTable->table(['width' => '100%', 'class' => 'table table-striped table-bordered']) !!}
 
-@push('third_party_scripts')
+@push('page_scripts')
     @include('layouts.datatables_js')
     {!! $dataTable->scripts() !!}
 @endpush


### PR DESCRIPTION
No @stack('third_party_scripts') exists on layouts/app.blade. So changing to push('page_scripts')