### PR TITLE
fix: Cannot be executed `php artisan infyom.publish:tables livewire`

### DIFF
--- a/views/scaffold/table/livewire/actions.php
+++ b/views/scaffold/table/livewire/actions.php
@@ -1,0 +1,12 @@
+<div class='btn-group'>
+    <a href="{{ $showUrl }}" class='btn btn-default btn-xs'>
+        <i class="fa fa-eye"></i>
+    </a>
+    <a href="{{ $editUrl }}" class='btn btn-default btn-xs'>
+        <i class="fa fa-edit"></i>
+    </a>
+    <a class='btn btn-danger btn-xs' wire:click="deleteRecord({{ $recordId }})"
+       onclick="confirm('Are you sure you want to remove this Record?') || event.stopImmediatePropagation()">
+        <i class="fa fa-trash"></i>
+    </a>
+</div>


### PR DESCRIPTION
Cannot be executed 
```
php artisan infyom.publish:tables livewire
```

Reference
https://infyom.com/open-source/laravelgenerator/docs/generator-options#livewire-tables

It happened with the following changes.
https://github.com/InfyOmLabs/laravel-generator/commit/fbc177206bdf0fc0024fa4d83fb96ea3b58b445f#diff-561740a5338bbac07c398fdee0cf41f38e50acaaaa23d61f85d8f758381a89feR48

Avoid errors by using php.
